### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         }
     },
     "require": {
+        "php": ">=5.4",
         "paragonie/random_compat": ">= 0.9.4"
     },
     "require-dev": {


### PR DESCRIPTION
add php version to composer deps, seems to use 5.4 at least for the short array syntax