### PR TITLE
trim base64 padding from tokens

### DIFF
--- a/src/AntiCSRF.php
+++ b/src/AntiCSRF.php
@@ -111,7 +111,7 @@ class AntiCSRF
 
         if (self::$hmac_ip !== false) {
             // Use HMAC to only allow this particular IP to send this request
-            $token = \base64_encode(
+            $token = self::encode(
                 \hash_hmac(
                     self::HASH_ALGO,
                     isset($_SERVER['REMOTE_ADDR'])
@@ -180,7 +180,7 @@ class AntiCSRF
             $expected = $stored['token'];
         } else {
             // We mixed in the client IP address to generate the output
-            $expected = \base64_encode(
+            $expected = self::encode(
                 \hash_hmac(
                     self::HASH_ALGO,
                     isset($_SERVER['REMOTE_ADDR'])
@@ -221,8 +221,8 @@ class AntiCSRF
      */
     private static function generateToken($lockto)
     {
-        $index = \base64_encode(\random_bytes(18));
-        $token = \base64_encode(\random_bytes(32));
+        $index = self::encode(\random_bytes(18));
+        $token = self::encode(\random_bytes(32));
 
         $_SESSION[self::SESSION_INDEX][$index] = [
             'created' => \intval(\date('YmdHis')),
@@ -273,6 +273,18 @@ class AntiCSRF
     private static function noHTML($untrusted)
     {
         return \htmlentities($untrusted, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    }
+
+    /**
+     * Encode string with base64, but strip padding.
+     * PHP base64_decode does not croak on that.
+     *
+     * @param string $s
+     * @return string
+     */
+    private static function encode($s)
+    {
+        return rtrim(base64_encode($s), '=');
     }
 
     /**


### PR DESCRIPTION
this avoids creating ugly tokens, that get html entities

```html
<input type="hidden" name="_CSRF_TOKEN" value="sDGZAkIzg5SiS5Enwf2YuzFL01LMjKENbnnRT3GhTM8&equals;" />
```