### PR TITLE
tests: allow specify php interpreter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,5 @@ php:
 install:
 
 - composer self-update && composer update
-- chmod +x ./run-tests.sh
 
 script: ./run-tests.sh

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -52,7 +52,7 @@ if [ $? -eq 0 ]; then
     echo
     echo -e "\033[33mBegin Unit Testing\033[0m"
     # Run the testing suite
-    php phpunit.phar --bootstrap "$cdir/autoload.php" "$cdir/tests"
+    ${PHP:-php} phpunit.phar --bootstrap "$cdir/autoload.php" "$cdir/tests"
     EXITCODE=$?
     # Cleanup
     if [ "$clean" -eq 1 ]; then


### PR DESCRIPTION
i have `php` pointing to php 5.3 version, but php 5.6 as `php56`. this allows to run tests via PHP env variable:

```sh
$ PHP=php56 ./run-tests.sh
```

pros: you could use similar PHP env var to run tests with different versions in travis ;)