### PR TITLE
drop ENT_HTML5

### DIFF
--- a/src/AntiCSRF.php
+++ b/src/AntiCSRF.php
@@ -272,7 +272,7 @@ class AntiCSRF
      */
     private static function noHTML($untrusted)
     {
-        return \htmlentities($untrusted, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        return \htmlentities($untrusted, ENT_QUOTES, 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
what for it's needed?
dropping it would fix creating `&lowbar;` entities, `_`-char is pretty safe in `<input>` fields, imho you really need only htmlspecialchars() not htmlentities() call, i.e to be safe only escaping out of double quotes.