### PR TITLE
Make the class instantiable

### DIFF
--- a/src/AntiCSRF.php
+++ b/src/AntiCSRF.php
@@ -64,7 +64,12 @@ class AntiCSRF
     {
         $this->post = $post === null ? $_POST : $post;
         $this->server = $server === null ? $_SERVER : $server;
-        $this->session = ($session === null && isset($_SESSION)) ? $_SESSION : (array) $session;
+
+        if ($session === null && isset($_SESSION)) {
+            $this->session =& $_SESSION;
+        } else {
+            $this->session = $session;
+        }
     }
 
     /**

--- a/src/AntiCSRF.php
+++ b/src/AntiCSRF.php
@@ -63,8 +63,8 @@ class AntiCSRF
     public function __construct(array $post = null, array $session = null, array $server = null)
     {
         $this->post = $post === null ? $_POST : $post;
-        $this->session = $session === null ? $_SESSION : $session;
         $this->server = $server === null ? $_SERVER : $server;
+        $this->session = ($session === null && isset($_SESSION)) ? $_SESSION : (array) $session;
     }
 
     /**

--- a/src/AntiCSRF.php
+++ b/src/AntiCSRF.php
@@ -56,6 +56,10 @@ class AntiCSRF
     public $hmac_ip = true;
     public $expire_old = false;
 
+    public $post;
+    public $session;
+    public $server;
+
     public function __construct(array $post = null, array $session = null, array $server = null)
     {
         $this->post = $post === null ? $_POST : $post;

--- a/tests/AntiCSRFTest.php
+++ b/tests/AntiCSRFTest.php
@@ -17,8 +17,13 @@ class AntiCSRFTest extends PHPUnit_Framework_TestCase
         $token_html = ob_get_clean();
 
         $this->assertFalse(
+            empty($csrft->session[AntiCSRF::SESSION_INDEX])
+        );
+
+        $this->assertFalse(
             empty($_SESSION[AntiCSRF::SESSION_INDEX])
         );
+
         $this->assertContains("<input", $token_html);
     }
 
@@ -33,7 +38,7 @@ class AntiCSRFTest extends PHPUnit_Framework_TestCase
         $result = $csrft->getTokenArray();
 
         $this->assertFalse(
-            empty($_SESSION[AntiCSRF::SESSION_INDEX])
+            empty($csrft->session[AntiCSRF::SESSION_INDEX])
         );
         $this->assertSame( [
 	        AntiCSRF::FORM_INDEX,

--- a/tests/AntiCSRFTest.php
+++ b/tests/AntiCSRFTest.php
@@ -12,7 +12,8 @@ class AntiCSRFTest extends PHPUnit_Framework_TestCase
         @session_start();
 
         ob_start();
-        AntiCSRF::insertToken();
+        $csrft = new AntiCSRF();
+        $csrft->insertToken();
         $token_html = ob_get_clean();
 
         $this->assertFalse(
@@ -28,7 +29,8 @@ class AntiCSRFTest extends PHPUnit_Framework_TestCase
     {
         @session_start();
 
-        $result = AntiCSRF::getTokenArray();
+        $csrft = new AntiCSRF();
+        $result = $csrft->getTokenArray();
 
         $this->assertFalse(
             empty($_SESSION[AntiCSRF::SESSION_INDEX])


### PR DESCRIPTION
Hello.
I'd like to use this library with [psr-7](https://github.com/oscarotero/psr7-middlewares) but because this library relies in global variables `$_POST`, `$_SESSION` and `$_SERVER`, I've changed some static methods of the class to be instantiable. This allows to reuse the library with custom post/session/server parameters. For example:
```php
use ParagonIE\AntiCSRF\AntiCSRF;

//Use the global variables $_POST, $_SESSION and $_SERVER
$csrf = new AntiCSRF();

//Use custom variables
$csrf = new AntiCSRF($request->getParsedBody(), $session, $request->getServerParams());

//check the request
$valid = $csrf->validateRequest();
```