### PR TITLE
Fix how variables are set in reconfigure() (#17)

### DIFF
--- a/src/AntiCSRF.php
+++ b/src/AntiCSRF.php
@@ -315,7 +315,7 @@ class AntiCSRF
                 case 'recycle_after':
                 case 'hmac_ip':
                 case 'expire_old':
-                    $this->${$opt} = $val;
+                    $this->$opt = $val;
                     break;
                 case 'hashAlgo':
                     if (\in_array($val, \hash_algos())) {


### PR DESCRIPTION
This allows using the reconfigure() function without a fatal error thrown.