### PR TITLE
Feature: can select 'PATH_INFO' as the locking mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea/

--- a/src/AntiCSRF.php
+++ b/src/AntiCSRF.php
@@ -88,6 +88,11 @@ class AntiCSRF
      */
     protected $expire_old = false;
 
+    /**
+     * @var string
+     */
+    protected $lock_type = 'REQUEST_URI';
+
     // Injected; defaults to references to superglobals
     public $post;
     public $session;
@@ -179,6 +184,14 @@ class AntiCSRF
     }
 
     /**
+     * @return string
+     */
+    public function getLockType(): string
+    {
+        return $this->lock_type;
+    }
+
+    /**
      * Retrieve a token array for unit testing endpoints
      *
      * @param string $lockTo
@@ -263,7 +276,7 @@ class AntiCSRF
         unset($this->session[$this->sessionIndex][$index]);
 
         // Which form action="" is this token locked to?
-        $lockTo = $this->server['REQUEST_URI'];
+        $lockTo = $this->server[$this->lock_type];
         if (\preg_match('#/$#', $lockTo)) {
             // Trailing slashes are to be ignored
             $lockTo = Binary::safeSubstr(
@@ -320,6 +333,11 @@ class AntiCSRF
                 case 'hashAlgo':
                     if (\in_array($val, \hash_algos())) {
                         $this->hashAlgo = $val;
+                    }
+                    break;
+                case 'lock_type':
+                    if (\in_array($val,array('REQUEST_URI','PATH_INFO'))) {
+                        $this->lock_type=$val;
                     }
                     break;
             }
@@ -397,4 +415,5 @@ class AntiCSRF
     {
         return \htmlentities($untrusted, ENT_QUOTES, 'UTF-8');
     }
+
 }


### PR DESCRIPTION
for cases when REQUEST_URI is too specific for implementation to be feasible (query-string params)
or in cases where query string params may/may not be present, and may not always hold same data.
Suitable for use with 'front-controller' type uris 