### PR TITLE
Removed duplicate string check for index and token

### DIFF
--- a/src/AntiCSRF.php
+++ b/src/AntiCSRF.php
@@ -334,10 +334,6 @@ class AntiCSRF
             return false;
         }
 
-        if (!\is_string($index) || !\is_string($token)) {
-            return false;
-        }
-
         // Grab the value stored at $index
         /** @var array<string, mixed> $stored */
         $stored = $sess[$index];


### PR DESCRIPTION
I found that the method `AntiCSRF::validateRequest()` contained duplicates of the same `if`. I couldn't see any reason for that so tried to remove it and it seems to work!