### PR TITLE
Update about the Life time Token validation

### DIFF
--- a/src/Reusable.php
+++ b/src/Reusable.php
@@ -82,6 +82,6 @@ class Reusable extends AntiCSRF
         }
         $dateTime = (new \DateTime($token['created-date']))->add($this->tokenLifetime);
         $now = new \DateTime();
-        return $dateTime >= $now;
+        return $dateTime >= $now ? false : true;
     }
 }


### PR DESCRIPTION
If tokenLifeTime is initialized and higher than the current date, the token will be deleted after the validateRequest. I think that reusable->deleteToken() should return false to ensure that the token stay valid during his life time.