### PR TITLE
API for throwing exceptions

### DIFF
--- a/src/AntiCSRF.php
+++ b/src/AntiCSRF.php
@@ -334,10 +334,6 @@ class AntiCSRF
             return false;
         }
 
-        if (!\is_string($index) || !\is_string($token)) {
-            return false;
-        }
-
         // Grab the value stored at $index
         /** @var array<string, mixed> $stored */
         $stored = $sess[$index];

--- a/src/Exception/AntiCSRFException.php
+++ b/src/Exception/AntiCSRFException.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace ParagonIE\AntiCSRF\Exception;
+
+/**
+ * Class AntiCSRFException
+ *
+ * @package ParagonIE\AntiCSRF
+ */
+abstract class AntiCSRFException extends \RuntimeException
+{
+}

--- a/src/Exception/FormLockException.php
+++ b/src/Exception/FormLockException.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace ParagonIE\AntiCSRF\Exception;
+
+/**
+ * Class FormLockException
+ *
+ * @package ParagonIE\AntiCSRF
+ */
+class FormLockException extends AntiCSRFException
+{
+    public static function create(string $lockTo): self
+    {
+        return new self(
+            \sprintf('Form action "%s" did not match the stored value', $lockTo)
+        );
+    }
+}

--- a/src/Exception/FormPostException.php
+++ b/src/Exception/FormPostException.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace ParagonIE\AntiCSRF\Exception;
+
+/**
+ * Class TokenNotInSessionException
+ *
+ * @package ParagonIE\AntiCSRF
+ */
+class FormPostException extends AntiCSRFException
+{
+    const CODE_MISSING_INDEX = 1;
+    const CODE_MISSING_TOKEN = 2;
+    const CODE_TYPE_INDEX = 3;
+    const CODE_TYPE_TOKEN = 4;
+
+    public static function missingIndex(string $formFieldName): self
+    {
+        return new self(
+            \sprintf('Missing index form post with name "%s"', $formFieldName),
+            self::CODE_MISSING_INDEX
+        );
+    }
+
+    public static function missingToken(string $formFieldName): self
+    {
+        return new self(
+            \sprintf('Missing token form post with name "%s"', $formFieldName),
+            self::CODE_MISSING_TOKEN
+        );
+    }
+
+    public static function indexTypeError(string $value): self
+    {
+        return new self(
+            \sprintf('Index form post value expected to be string, "%s" given', \gettype($value)),
+            self::CODE_TYPE_INDEX
+        );
+    }
+
+    public static function tokenTypeError(string $value): self
+    {
+        return new self(
+            \sprintf('Token form post value expected to be string, "%s" given', \gettype($value)),
+            self::CODE_TYPE_TOKEN
+        );
+    }
+}

--- a/src/Exception/TokenHashException.php
+++ b/src/Exception/TokenHashException.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace ParagonIE\AntiCSRF\Exception;
+
+/**
+ * Class TokenHashException
+ *
+ * @package ParagonIE\AntiCSRF
+ */
+class TokenHashException extends AntiCSRFException
+{
+    public static function create(string $token): self
+    {
+        return new self(
+            \sprintf('Token "%s" did not match the stored value', $token)
+        );
+    }
+}

--- a/src/Exception/TokenIndexNotInSessionException.php
+++ b/src/Exception/TokenIndexNotInSessionException.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace ParagonIE\AntiCSRF\Exception;
+
+/**
+ * Class TokenIndexNotInSessionException
+ *
+ * @package ParagonIE\AntiCSRF
+ */
+class TokenIndexNotInSessionException extends AntiCSRFException
+{
+    const CODE_NATIVE = 1;
+    const CODE_CONSTRUCTOR = 2;
+
+    public static function fromNative(string $sessionIndex): self
+    {
+        return new self(
+            \sprintf('Token not found in native $_SESSION at index "%s"', $sessionIndex),
+            self::CODE_NATIVE
+        );
+    }
+
+    public static function fromConstructor(string $sessionIndex): self
+    {
+        return new self(
+            \sprintf('Token not found in constructor session at index "%s"', $sessionIndex),
+            self::CODE_CONSTRUCTOR
+        );
+    }
+}

--- a/src/Exception/TokenNotInSessionException.php
+++ b/src/Exception/TokenNotInSessionException.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace ParagonIE\AntiCSRF\Exception;
+
+/**
+ * Class TokenNotInSessionException
+ *
+ * @package ParagonIE\AntiCSRF
+ */
+class TokenNotInSessionException extends AntiCSRFException
+{
+    public static function create(string $formIndex): self
+    {
+        return new self(
+            \sprintf('Token with index "%s" not found in session', $formIndex),
+        );
+    }
+}


### PR DESCRIPTION
This is an experiment I made after thinking of ways to help debugging CSRF validation issues or giving better errors to end users.

The existing validation method `validateRequest()` only returns a boolean and still does in this PR. To opt-in to this new "API" a new method is added `validateRequestOrThrow()`. That name is questionable, naming things is difficult 😉 

I was thinking of writing unit tests but the `validateRequest()` isn't tested today.