### PR TITLE
 Add lockTo parameter to validateRequest method

### DIFF
--- a/src/AntiCSRF.php
+++ b/src/AntiCSRF.php
@@ -296,7 +296,7 @@ class AntiCSRF
      * @return bool
      * @throws \TypeError
      */
-    public function validateRequest(): bool
+    public function validateRequest(string $lockTo = ''): bool
     {
         if ($this->useNativeSession) {
             if (!isset($_SESSION[$this->sessionIndex])) {
@@ -349,7 +349,9 @@ class AntiCSRF
 
         // Which form action="" is this token locked to?
         /** @var string $lockTo */
-        $lockTo = $this->server[$this->lock_type];
+        if (empty($lockTo)) {
+            $lockTo = $this->server[$this->lock_type];
+        }
         if (\preg_match('#/$#', $lockTo)) {
             // Trailing slashes are to be ignored
             $lockTo = Binary::safeSubstr(


### PR DESCRIPTION
Tries to solve single access point web apps use case, where final URL semantics may not be determined only by `REQUEST_URI` server variable.

A couple of examples:

- parameter travels in a hidden field, web app knows how to route the request 
```
curl -X POST -d "_CSRF_INDEX=hashedval" -d "_CSRF_TOKEN=hashedval2" -d "op=CB3FD" http://domain/application.php
curl -X POST -d "_CSRF_INDEX=hashedval" -d "_CSRF_TOKEN=hashedval2" -d "op=B4A3FF" http://domain/application.php
```
Those two request may seem the same to the lib, but they're intended to different operations/forms.

- parameter travels in URL, but it's not the only one
```
curl -X POST -d "_CSRF_INDEX=hashedval" -d "_CSRF_TOKEN=hashedval2" http://domain/application.php?_sq=hashedval&op=CB3FD
```
Here i may need `op` to route the request but `_sq` it's generating noise in the `lockTo` comparison.

I know the proposed solution in this PR may leave some spaces to misuse (would require proper documentation), but if i lock the Token to a specific application parameter, i should be able to provide it too in the validation stage.

If you think there's a better way to solve this use case, please feel free to mention it.

Regards.
