### PR TITLE
fix: replaced Twig_SimpleFunction with \Twig\TwigFunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ First, add a filter like this one:
 ```php
 use \ParagonIE\AntiCSRF\AntiCSRF;
 $twigEnv->addFunction(
-    new \Twig_SimpleFunction(
+    new \Twig\TwigFunction(
         'form_token',
         function($lock_to = null) {
             static $csrf;


### PR DESCRIPTION
As of Twig 2.x, the Twig_SimpleFunction class was removed in Twig 3.x and replaced with \Twig\TwigFunction instead -> https://twig.symfony.com/doc/1.x/deprecated.html & https://twig.symfony.com/doc/2.x/deprecated.html

Ensures people following the readme don't get confused.