### PR TITLE
Fix: Using hash_hmac_algos() instead of hash_algos()

### DIFF
--- a/src/AntiCSRF.php
+++ b/src/AntiCSRF.php
@@ -446,7 +446,7 @@ class AntiCSRF
                     $this->$opt = $val;
                     break;
                 case 'hashAlgo':
-                    if (\in_array($val, \hash_algos(), true)) {
+                    if (\in_array($val, \hash_hmac_algos(), true)) {
                         $this->hashAlgo = (string) $val;
                     }
                     break;


### PR DESCRIPTION
The hashAlgo property is used with the hash_hmac function, the list of registered hash algorithms suitable for hash_hmac is obtained with hash_hmac_algos().

### Use of \hash_hmac function:

https://github.com/paragonie/anti-csrf/blob/642ebf73a9fa6cd20fd221cdd70188223182e7c6/src/AntiCSRF.php#L281-L282

https://github.com/paragonie/anti-csrf/blob/642ebf73a9fa6cd20fd221cdd70188223182e7c6/src/AntiCSRF.php#L409-L410
